### PR TITLE
fix hyva/react-checkout path

### DIFF
--- a/reactapp/package.json
+++ b/reactapp/package.json
@@ -14,7 +14,7 @@
   "proxy": "https://demo.hyva.io",
   "dependencies": {
     "@heroicons/react": "^1.0.1",
-    "@hyva/react-checkout": "file:../../../../../vendor/hyva-themes/magento2-hyva-checkout/src/reactapp/src",
+    "@hyva/react-checkout": "file:../../../../../vendor/hyva-themes/magento2-hyva-checkout/src/reactapp",
     "formik": "^2.2.6",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",


### PR DESCRIPTION
The current path throws an error on `npm install`:
```
npm ERR! Could not install from "../../../vendor/hyva-themes/magento2-hyva-checkout/src/reactapp/src" as it does not contain a package.json file.
```

Because the `package.json` is one folder before the given path.